### PR TITLE
fix: PDO constructor was not called when using db transaction

### DIFF
--- a/pdo/Oci8PDO.php
+++ b/pdo/Oci8PDO.php
@@ -289,6 +289,16 @@ class Oci8PDO extends PDO
     }
 
     /**
+     * Returns true if the current process is in a transaction
+     *
+     * @return bool
+     */
+    public function inTransaction()
+    {
+        return $this->_isTransaction;
+    }
+
+    /**
      * Retrieve a database connection attribute
      *
      * @return mixed


### PR DESCRIPTION
Using transaction will prompt this following error `PDO::inTransaction(): SQLSTATE[00000]: No error: PDO constructor was not called`.

reference:
https://github.com/yiisoft/yii2/issues/18471
https://github.com/sfedosimov/yii2-oci8pdo/pull/5